### PR TITLE
Add Spot Price Calculation for AEMO NEM Integration

### DIFF
--- a/custom_components/aemo_nem/config_flow.py
+++ b/custom_components/aemo_nem/config_flow.py
@@ -26,7 +26,9 @@ DATA_SCHEMA = vol.Schema(
         vol.Required("state_nsw", default=False): cv.boolean,
         vol.Required("state_vic", default=False): cv.boolean,
         vol.Required("state_tas", default=False): cv.boolean,
-        vol.Required("state_sa", default=False): cv.boolean,
+        vol.Required("state_sa", default=False): cv.boolean,                vol.Required("network"): str,
+        vol.Required("network"): str,
+        vol.Required("tariff"): str,
     }
 )
 

--- a/custom_components/aemo_nem/manifest.json
+++ b/custom_components/aemo_nem/manifest.json
@@ -11,7 +11,8 @@
   "loggers": ["aemo_nem"],
   "requirements": [
 
-      "aemonemdata==2024.8.0"
+      "aemonemdata==2024.8.0",
+      "aemo-to-tariff==0.1.8"
   ],
   "ssdp": [],
 


### PR DESCRIPTION
This adds a new sensor entity to calculate spot prices based on network and tariff information. Key changes:

- Added AemoNemSpotPriceSensorEntity class
- Integrated spot_to_tariff function from aemo_to_tariff module
- Modified async_setup_entry to create the new sensor

I need help with:
1. Ensuring network and tariff info is correctly passed in entry.data
2. Verifying the spot_to_tariff function implementation
3. Confirming current_timestamp availability in coordinator data

Please review and advise on any necessary adjustments before merging. Thanks!