### PR TITLE
Cabberley patch 1

### DIFF
--- a/custom_components/aemo_nem/binary_sensor.py
+++ b/custom_components/aemo_nem/binary_sensor.py
@@ -54,7 +54,7 @@ class RedbackTechBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
             + "_"
             + device_key.lower()
             + "_"
-            + entity_key
+            + entity_key.lower()
         )
         self.entity_name = entity_key
         self.device_key=device_key

--- a/custom_components/aemo_nem/sensor.py
+++ b/custom_components/aemo_nem/sensor.py
@@ -65,9 +65,9 @@ class AemoNemSensorEntity(CoordinatorEntity, SensorEntity):
         self.device_key=device_key
         self.entity_id = (
             "sensor.aemo_nem_"
-            + device_key
+            + device_key.lower()
             + "_"
-            + entity_key
+            + entity_key.lower()
         )
 
     @callback
@@ -197,9 +197,9 @@ class AemoNemInterconnectorSensorEntity(CoordinatorEntity, SensorEntity):
         self.device_key=device_key
         self.entity_id = (
             "sensor.aemo_nem_"
-            + device_key
+            + device_key.lower()
             + "_"
-            + entity_key
+            + entity_key.lower()
         )
 
     @callback


### PR DESCRIPTION
**Breaking Change.**
This will create new Entity IDs if you do not delete your existing AEMO devices/sensors before updating. 

HA introduced a new entity ID name check that rejects a proposed name with Upper Case. Previous behaviour was that it would allow the uppercase and convert it to lower case when it created the Entity_id.

## Summary by Sourcery

Enhancements:
- Ensure sensor and binary sensor entity IDs are consistently generated using lowercase device and entity keys to avoid rejection by Home Assistant’s new uppercase name checks.