### PR TITLE
fix(entity_id): slugify device/entity keys to avoid invalid characters (HA 2027.2.0)

### DIFF
--- a/custom_components/aemo_nem/binary_sensor.py
+++ b/custom_components/aemo_nem/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from .const import (
     DOMAIN,
@@ -49,12 +50,14 @@ class RedbackTechBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
     def __init__(self, coordinator, device_key, entity_key):
         super().__init__(coordinator)
         self.entity_key = entity_key
+        # Use slugify() to ensure entity_id contains only valid characters
+        # (HA 2027.2.0 will reject entity IDs with hyphens or other invalid chars).
         self.entity_id = (
             "binary_sensor.aemonem"
             + "_"
-            + device_key.lower()
+            + slugify(device_key)
             + "_"
-            + entity_key.lower()
+            + slugify(entity_key)
         )
         self.entity_name = entity_key
         self.device_key=device_key

--- a/custom_components/aemo_nem/sensor.py
+++ b/custom_components/aemo_nem/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from .const import ATTRIBUTION, DOMAIN, AEMONEM_COORDINATOR, AEMO_WWW, MANUFACTURER, LOGGER
 from .coordinator import AemoNemUpdateCoordinator
@@ -63,11 +64,14 @@ class AemoNemSensorEntity(CoordinatorEntity, SensorEntity):
         self.entity_name = entity_key
         self.entity_value  = entity_data
         self.device_key=device_key
+        # Use slugify() to ensure entity_id contains only valid characters.
+        # Hyphens in interconnector codes (e.g. V-SA, V-S-MNSP1) are not valid
+        # in HA entity IDs and will be rejected from HA 2027.2.0.
         self.entity_id = (
             "sensor.aemo_nem_"
-            + device_key.lower()
+            + slugify(device_key)
             + "_"
-            + entity_key.lower()
+            + slugify(entity_key)
         )
 
     @callback
@@ -195,11 +199,15 @@ class AemoNemInterconnectorSensorEntity(CoordinatorEntity, SensorEntity):
         self.entity_name = entity_key
         self.entity_value  = entity_data["value"]
         self.device_key=device_key
+        # Use slugify() to ensure entity_id contains only valid characters.
+        # Interconnector codes (V-SA, V-S-MNSP1, T-V-MNSP1, etc.) contain
+        # hyphens that are not valid in HA entity IDs and will be rejected
+        # from HA 2027.2.0.
         self.entity_id = (
             "sensor.aemo_nem_"
-            + device_key.lower()
+            + slugify(device_key)
             + "_"
-            + entity_key.lower()
+            + slugify(entity_key)
         )
 
     @callback


### PR DESCRIPTION
## Plain English

Home Assistant 2027.2.0 will refuse to load entities whose `entity_id` contains characters other than `[a-z0-9_]`. Several interconnector codes used by this integration (`V-SA`, `V-S-MNSP1`, `T-V-MNSP1`, etc.) contain hyphens, which produce invalid entity IDs like `sensor.aemo_nem_vic1_v-sa`.

The current code uses `.lower()` to normalise case, but that leaves hyphens (and any future special characters) untouched. This PR switches to `homeassistant.util.slugify()` so any non-alphanumeric/underscore character is collapsed to `_`.

## Current warning

With HA 2026.6.x I see this in the log every boot (12 occurrences, one per affected interconnector):

```
WARNING  helpers/frame.py:305
Detected that custom integration 'aemo_nem' sets an invalid entity ID:
  'sensor.aemo_nem_vic1_v-sa'
  'sensor.aemo_nem_vic1_v-s-mnsp1'
  'sensor.aemo_nem_tas1_t-v-mnsp1'
  'sensor.aemo_nem_sa1_v-sa'
  'sensor.aemo_nem_sa1_v-s-mnsp1'
  ... (12 total)
... This will stop working in Home Assistant 2027.2.0, please create a bug report at
https://github.com/cabberley/HA_AemoNemData/issues
```

## Changes

Three call sites updated (`sensor.py`: `AemoNemSensorEntity.__init__` and `AemoNemInterconnectorSensorEntity.__init__`; `binary_sensor.py`: `RedbackTechBinarySensorEntity.__init__`):

```python
# before
self.entity_id = (
    "sensor.aemo_nem_"
    + device_key.lower()
    + "_"
    + entity_key.lower()
)

# after
from homeassistant.util import slugify
...
self.entity_id = (
    "sensor.aemo_nem_"
    + slugify(device_key)
    + "_"
    + slugify(entity_key)
)
```

## Renames after upgrade

| Before | After |
|---|---|
| `sensor.aemo_nem_vic1_v-sa` | `sensor.aemo_nem_vic1_v_sa` |
| `sensor.aemo_nem_vic1_v-s-mnsp1` | `sensor.aemo_nem_vic1_v_s_mnsp1` |
| `sensor.aemo_nem_tas1_t-v-mnsp1` | `sensor.aemo_nem_tas1_t_v_mnsp1` |
| `sensor.aemo_nem_sa1_v-sa` | `sensor.aemo_nem_sa1_v_sa` |

Users with automations or dashboards referencing the hyphenated IDs will need to update them after upgrading. This is the same migration that will be forced when HA 2027.2.0 removes support for invalid entity IDs.

## Validation

- AST parse of modified files OK.
- `slugify('V-SA')` → `'v_sa'`, `slugify('V-S-MNSP1')` → `'v_s_mnsp1'`, `slugify('T-V-MNSP1')` → `'t_v_mnsp1'`, `slugify('VIC1')` → `'vic1'`.
- Existing case-only keys (`VIC1`, `NSW1_QLD1`) are unchanged in behaviour.

Happy to update the changelog or bump the manifest version if you'd like — wasn't sure which version line to pick.

## Summary by Sourcery

Bug Fixes:
- Normalize sensor and binary sensor entity_ids using slugify so interconnector codes with hyphens are converted to valid Home Assistant entity IDs.